### PR TITLE
external sensor data for attributes

### DIFF
--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -284,17 +284,20 @@
 
         renderAttribute(data) {
             const computeFunc = data.compute || (v => v);
-            const isValidSensorData = data && `${this.config.sensorEntity}_${data.key}` in this._hass.states;
+            const isValidEntitySensorData = data && `${this.config.sensorEntity}_${data.key}` in this._hass.states;
+            const isValidExternalSensorData = data && data.key in this._hass.states;
             const isValidAttribute = data && data.key in this.stateObj.attributes;
             const isValidEntityData = data && data.key in this.stateObj;
 
-            const value = isValidSensorData
+            const value = isValidEntitySensorData
                 ? computeFunc(this._hass.states[`${this.config.sensorEntity}_${data.key}`].state) + (data.unit || '')
-                : isValidAttribute
-                    ? computeFunc(this.stateObj.attributes[data.key]) + (data.unit || '')
-                    : isValidEntityData
-                        ? computeFunc(this.stateObj[data.key]) + (data.unit || '')
-                        : null;
+                : isValidExternalSensorData
+                    ? computeFunc(this._hass.states[data.key].state) + (data.unit || '')
+                    : isValidAttribute
+                        ? computeFunc(this.stateObj.attributes[data.key]) + (data.unit || '')
+                        : isValidEntityData
+                            ? computeFunc(this.stateObj[data.key]) + (data.unit || '')
+                            : null;
             const attribute = html`<div>
                 ${data.icon && this.renderIcon(data)}
                 ${(data.label || '') + (value !== null ? value : this._hass.localize('state.default.unavailable'))}

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -111,7 +111,7 @@
             attributes: {
                 main_brush: {key: 'main_brush'},
                 side_brush: {key: 'side_brush'},
-                filter: {key: 'filter'},
+                filter: {key: 'main_filter'},
                 sensor: {key: 'sensor_cleaning'},
             },
         },

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -109,10 +109,10 @@
                 status: {key: 'state'},
             },
             attributes: {
-                main_brush: {key: 'mainBrush'},
-                side_brush: {key: 'sideBrush'},
+                main_brush: {key: 'main_brush'},
+                side_brush: {key: 'side_brush'},
                 filter: {key: 'filter'},
-                sensor: {key: 'sensor'},
+                sensor: {key: 'sensor_cleaning'},
             },
         },
         roomba: {

--- a/xiaomi-vacuum-card.js
+++ b/xiaomi-vacuum-card.js
@@ -110,7 +110,7 @@
             },
             attributes: {
                 main_brush: {key: 'main_brush'},
-                side_brush: {key: 'side_brush'},
+                side_brush: {key: 'right_brush'},
                 filter: {key: 'main_filter'},
                 sensor: {key: 'sensor_cleaning'},
             },


### PR DESCRIPTION
current code assumes the valetudo vacuums follow the ```vacuum.valetudo_vacuumname``` pattern and then it would in fact read states of the new sensors created by merging the two:
`${this.config.sensorEntity}_${data.key}`

```sensor.valetudo_vacuumname_main_brush```
my vacuum was always named ```vacuum.vacuumname```
current code in fact allows reading any entity from hassio if specified as
```key: sensor.vacuumname_main_brush```